### PR TITLE
Add additional functions for attaching and detaching Blazor navigation manager to/from browser renderer event delegators

### DIFF
--- a/patches/7.x/aspnetcore.patch
+++ b/patches/7.x/aspnetcore.patch
@@ -1,5 +1,5 @@
 diff --git a/src/Components/Web.JS/src/Boot.WebAssembly.ts b/src/Components/Web.JS/src/Boot.WebAssembly.ts
-index e46702cc4d..ecdf14d731 100644
+index e46702cc4d..352e69f7bb 100644
 --- a/src/Components/Web.JS/src/Boot.WebAssembly.ts
 +++ b/src/Components/Web.JS/src/Boot.WebAssembly.ts
 @@ -17,6 +17,7 @@ import { WebAssemblyStartOptions } from './Platform/WebAssemblyStartOptions';
@@ -22,7 +22,7 @@ index e46702cc4d..ecdf14d731 100644
    setDispatchEventMiddleware((browserRendererId, eventHandlerId, continuation) => {
      // It's extremely unusual, but an event can be raised while we're in the middle of synchronously applying a
      // renderbatch. For example, a renderbatch might mutate the DOM in such a way as to cause an <input> to lose
-@@ -74,30 +80,37 @@ async function boot(options?: Partial<WebAssemblyStartOptions>): Promise<void> {
+@@ -74,30 +80,39 @@ async function boot(options?: Partial<WebAssemblyStartOptions>): Promise<void> {
    };
  
    // Configure navigation via JS Interop
@@ -74,12 +74,14 @@ index e46702cc4d..ecdf14d731 100644
 +  };
 +
 +  Blazor.removeNavigationEventListeners = () => Blazor._internal.navigationManager.removeNavigationEventListeners();
++  Blazor.reattachEventDelegators = () => Blazor._internal.navigationManager.reattachAllEventDelegators();
++  Blazor.detachEventDelegators = () => Blazor._internal.navigationManager.detachAllEventDelegators();
 +
 +  Blazor.addNavigationEventListeners();
  
    const candidateOptions = options ?? {};
  
-@@ -105,7 +118,11 @@ async function boot(options?: Partial<WebAssemblyStartOptions>): Promise<void> {
+@@ -105,7 +120,11 @@ async function boot(options?: Partial<WebAssemblyStartOptions>): Promise<void> {
    const environment = candidateOptions.environment;
  
    // Fetch the resources and prepare the Mono runtime
@@ -92,7 +94,7 @@ index e46702cc4d..ecdf14d731 100644
  
    // Leverage the time while we are loading boot.config.json from the network to discover any potentially registered component on
    // the document.
-@@ -132,11 +149,15 @@ async function boot(options?: Partial<WebAssemblyStartOptions>): Promise<void> {
+@@ -132,11 +151,15 @@ async function boot(options?: Partial<WebAssemblyStartOptions>): Promise<void> {
    };
  
    const bootConfigResult: BootConfigResult = await bootConfigPromise;
@@ -111,7 +113,7 @@ index e46702cc4d..ecdf14d731 100644
    ]);
  
    try {
-@@ -146,7 +167,7 @@ async function boot(options?: Partial<WebAssemblyStartOptions>): Promise<void> {
+@@ -146,7 +169,7 @@ async function boot(options?: Partial<WebAssemblyStartOptions>): Promise<void> {
    }
  
    // Start up the application
@@ -121,25 +123,29 @@ index e46702cc4d..ecdf14d731 100644
    // only end when the app finishes running
    jsInitializer.invokeAfterStartedCallbacks(Blazor);
 diff --git a/src/Components/Web.JS/src/GlobalExports.ts b/src/Components/Web.JS/src/GlobalExports.ts
-index 4fca849b69..64734c36ca 100644
+index 4fca849b69..d406de7ace 100644
 --- a/src/Components/Web.JS/src/GlobalExports.ts
 +++ b/src/Components/Web.JS/src/GlobalExports.ts
-@@ -21,6 +21,9 @@ interface IBlazor {
+@@ -21,6 +21,11 @@ interface IBlazor {
    navigateTo: (uri: string, options: NavigationOptions) => void;
    registerCustomEventType: (eventName: string, options: EventTypeOptions) => void;
  
 +  addNavigationEventListeners: () => void;
 +  removeNavigationEventListeners: () => void;
++  reattachEventDelegators: () => void;
++  detachEventDelegators: () => void;
 +
    disconnect?: () => void;
    reconnect?: (existingConnection?: HubConnection) => Promise<boolean>;
    defaultReconnectionHandler?: DefaultReconnectionHandler;
-@@ -73,6 +76,8 @@ interface IBlazor {
+@@ -73,6 +78,10 @@ interface IBlazor {
  export const Blazor: IBlazor = {
    navigateTo,
    registerCustomEventType,
 +  addNavigationEventListeners: () => { /* do nothing, set by boot(). */ },
 +  removeNavigationEventListeners: () => { /* do nothing, set by boot(). */ },
++  reattachEventDelegators: () => { /* do nothing, set by boot(). */ },
++  detachEventDelegators: () => { /* do nothing, set by boot(). */ },
    rootComponents: RootComponentsFunctions,
  
    _internal: {
@@ -545,11 +551,73 @@ index 4c40a349f4..2124289daa 100644
  }
  
  // This type doesn't have to align with anything in BootConfig.
+diff --git a/src/Components/Web.JS/src/Rendering/Events/EventDelegator.ts b/src/Components/Web.JS/src/Rendering/Events/EventDelegator.ts
+index 55c8a8a498..56d718357e 100644
+--- a/src/Components/Web.JS/src/Rendering/Events/EventDelegator.ts
++++ b/src/Components/Web.JS/src/Rendering/Events/EventDelegator.ts
+@@ -119,6 +119,14 @@ export class EventDelegator {
+     this.eventInfoStore.addGlobalListener('click'); // Ensure we always listen for this
+   }
+ 
++  public removeNotifyAfterClick(callback: (event: MouseEvent) => void): void {
++    this.eventInfoStore.removeGlobalListener('click');
++    const index = this.afterClickCallbacks.indexOf(callback);
++    if (index !== -1) {
++      this.afterClickCallbacks.splice(index, 1);
++    }
++  }
++
+   public setStopPropagation(element: Element, eventName: string, value: boolean): void {
+     const infoForElement = this.getEventHandlerInfosForElement(element, true)!;
+     infoForElement.stopPropagation(eventName, value);
+@@ -259,6 +267,15 @@ class EventInfoStore {
+     }
+   }
+ 
++  public removeGlobalListener(eventName: string) {
++    eventName = getBrowserEventName(eventName);
++
++    if (--this.countByEventName[eventName] === 0) {
++      delete this.countByEventName[eventName];
++      document.removeEventListener(eventName, this.globalListener);
++    }
++  }
++
+   public update(oldEventHandlerId: number, newEventHandlerId: number) {
+     if (Object.prototype.hasOwnProperty.call(this.infosByEventHandlerId, newEventHandlerId)) {
+       // Should never happen, but we want to know if it does
+diff --git a/src/Components/Web.JS/src/Rendering/Renderer.ts b/src/Components/Web.JS/src/Rendering/Renderer.ts
+index 9c65d5d1ed..57c17f6fd9 100644
+--- a/src/Components/Web.JS/src/Rendering/Renderer.ts
++++ b/src/Components/Web.JS/src/Rendering/Renderer.ts
+@@ -14,6 +14,10 @@ interface BrowserRendererRegistry {
+ const browserRenderers: BrowserRendererRegistry = {};
+ let shouldResetScrollAfterNextBatch = false;
+ 
++export function getBrowserRendererRegistry(): BrowserRendererRegistry {
++  return browserRenderers;
++}
++
+ export function attachRootComponentToLogicalElement(browserRendererId: number, logicalElement: LogicalElement, componentId: number, appendContent: boolean): void {
+   let browserRenderer = browserRenderers[browserRendererId];
+   if (!browserRenderer) {
 diff --git a/src/Components/Web.JS/src/Services/NavigationManager.ts b/src/Components/Web.JS/src/Services/NavigationManager.ts
-index c3321da6d9..c3d8df65fa 100644
+index c3321da6d9..da4d6fb886 100644
 --- a/src/Components/Web.JS/src/Services/NavigationManager.ts
 +++ b/src/Components/Web.JS/src/Services/NavigationManager.ts
-@@ -18,14 +18,20 @@ let notifyLocationChangingCallback: ((callId: number, uri: string, state: string
+@@ -2,9 +2,10 @@
+ // The .NET Foundation licenses this file to you under the MIT license.
+ 
+ import '@microsoft/dotnet-js-interop';
+-import { resetScrollAfterNextBatch } from '../Rendering/Renderer';
++import { getBrowserRendererRegistry, resetScrollAfterNextBatch } from '../Rendering/Renderer';
+ import { EventDelegator } from '../Rendering/Events/EventDelegator';
+ 
++const attachedEventDelegators = new Set<EventDelegator>();
+ let hasEnabledNavigationInterception = false;
+ let hasRegisteredNavigationEventListeners = false;
+ let hasLocationChangingEventListeners = false;
+@@ -18,14 +19,22 @@ let notifyLocationChangingCallback: ((callId: number, uri: string, state: string
  let popStateCallback: ((state: PopStateEvent) => Promise<void> | void) = onBrowserInitiatedPopState;
  let resolveCurrentNavigation: ((shouldContinueNavigation: boolean) => void) | null = null;
  
@@ -562,6 +630,8 @@ index c3321da6d9..c3d8df65fa 100644
  export const internalFunctions = {
    listenForNavigationEvents,
 +  removeNavigationEventListeners,
++  reattachAllEventDelegators,
++  detachAllEventDelegators,
    enableNavigationInterception,
    setHasLocationChangingListeners,
    endLocationChanging,
@@ -571,7 +641,7 @@ index c3321da6d9..c3d8df65fa 100644
    getLocationHref: (): string => location.href,
  };
  
-@@ -45,6 +51,15 @@ function listenForNavigationEvents(
+@@ -45,6 +54,15 @@ function listenForNavigationEvents(
    currentHistoryIndex = history.state?._index ?? 0;
  }
  
@@ -587,7 +657,98 @@ index c3321da6d9..c3d8df65fa 100644
  function enableNavigationInterception(): void {
    hasEnabledNavigationInterception = true;
  }
-@@ -250,7 +265,7 @@ async function onPopState(state: PopStateEvent) {
+@@ -54,37 +72,68 @@ function setHasLocationChangingListeners(hasListeners: boolean) {
+ }
+ 
+ export function attachToEventDelegator(eventDelegator: EventDelegator): void {
++  if (attachedEventDelegators.has(eventDelegator)) {
++    return;
++  }
++
+   // We need to respond to clicks on <a> elements *after* the EventDelegator has finished
+   // running its simulated bubbling process so that we can respect any preventDefault requests.
+   // So instead of registering our own native event, register using the EventDelegator.
+-  eventDelegator.notifyAfterClick(event => {
+-    if (!hasEnabledNavigationInterception) {
+-      return;
+-    }
++  console.log('Attaching to event delegator');
++  eventDelegator.notifyAfterClick(notifyAfterClickCallback);
++  attachedEventDelegators.add(eventDelegator);
++}
+ 
+-    if (event.button !== 0 || eventHasSpecialKey(event)) {
+-      // Don't stop ctrl/meta-click (etc) from opening links in new tabs/windows
+-      return;
+-    }
++function detachFromEventDelegator(eventDelegator: EventDelegator): void {
++  if (attachedEventDelegators.delete(eventDelegator)) {
++    console.log('Detaching to event delegator');
++    eventDelegator.removeNotifyAfterClick(notifyAfterClickCallback);
++  }
++}
+ 
+-    if (event.defaultPrevented) {
+-      return;
+-    }
++function reattachAllEventDelegators() {
++  const browserRenderers = getBrowserRendererRegistry();
++  for (const browserRendererId in browserRenderers) {
++    console.log(`Attempting to reattach event delegator for browser render ID ${browserRendererId}`);
++    attachToEventDelegator(browserRenderers[browserRendererId].eventDelegator);
++  }
++}
+ 
+-    // Intercept clicks on all <a> elements where the href is within the <base href> URI space
+-    // We must explicitly check if it has an 'href' attribute, because if it doesn't, the result might be null or an empty string depending on the browser
+-    const anchorTarget = findAnchorTarget(event);
++function detachAllEventDelegators() {
++  const browserRenderers = getBrowserRendererRegistry();
++  for (const browserRendererId in browserRenderers) {
++    console.log(`Attempting to detach event delegator for browser render ID ${browserRendererId}`);
++    detachFromEventDelegator(browserRenderers[browserRendererId].eventDelegator);
++  }
++}
+ 
+-    if (anchorTarget && canProcessAnchor(anchorTarget)) {
+-      const href = anchorTarget.getAttribute('href')!;
+-      const absoluteHref = toAbsoluteUri(href);
++function notifyAfterClickCallback(event: MouseEvent): void {
++  if (!hasEnabledNavigationInterception) {
++    return;
++  }
+ 
+-      if (isWithinBaseUriSpace(absoluteHref)) {
+-        event.preventDefault();
+-        performInternalNavigation(absoluteHref, /* interceptedLink */ true, /* replace */ false);
+-      }
++  if (event.button !== 0 || eventHasSpecialKey(event)) {
++    // Don't stop ctrl/meta-click (etc) from opening links in new tabs/windows
++    return;
++  }
++
++  if (event.defaultPrevented) {
++    return;
++  }
++
++  // Intercept clicks on all <a> elements where the href is within the <base href> URI space
++  // We must explicitly check if it has an 'href' attribute, because if it doesn't, the result might be null or an empty string depending on the browser
++  const anchorTarget = findAnchorTarget(event);
++
++  if (anchorTarget && canProcessAnchor(anchorTarget)) {
++    const href = anchorTarget.getAttribute('href')!;
++    const absoluteHref = toAbsoluteUri(href);
++
++    if (isWithinBaseUriSpace(absoluteHref)) {
++      event.preventDefault();
++      performInternalNavigation(absoluteHref, /* interceptedLink */ true, /* replace */ false);
+     }
+-  });
++  }
+ }
+ 
+ // For back-compat, we need to accept multiple overloads
+@@ -250,7 +299,7 @@ async function onPopState(state: PopStateEvent) {
  let testAnchor: HTMLAnchorElement;
  export function toAbsoluteUri(relativeUri: string): string {
    testAnchor = testAnchor || document.createElement('a');
@@ -596,7 +757,7 @@ index c3321da6d9..c3d8df65fa 100644
    return testAnchor.href;
  }
  
-@@ -287,7 +302,7 @@ function findClosestAnchorAncestorLegacy(element: Element | null, tagName: strin
+@@ -287,7 +336,7 @@ function findClosestAnchorAncestorLegacy(element: Element | null, tagName: strin
  }
  
  function isWithinBaseUriSpace(href: string) {


### PR DESCRIPTION
This makes it so that you can navigate from one Blazor MFE to another and back. The event delegator is owned by a BrowserRenderer created by the Blazor WASM runtime. When the BrowserRenderer is created, it attaches the Blazor navigation manager to its event delegator. This registers a global click handler along with an after click callback. This callback state gets cleared now with the functions exposed on the Blazor object by this patch. The idea is that the event delegators get detached when a Blazor MFE is unmounted and reattached when the MFE is mounted.